### PR TITLE
Update frame.py

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -198,6 +198,7 @@ from pandas.core.sorting import (
     nargsort,
 )
 
+from pandas.errors import InvalidIndexError
 from pandas.io.common import get_handle
 from pandas.io.formats import (
     console,
@@ -3872,7 +3873,7 @@ class DataFrame(NDFrame, OpsMixin):
             #  or ValueError
             series._mgr.setitem_inplace(loc, value)
 
-        except (KeyError, TypeError, ValueError):
+        except (KeyError, TypeError, ValueError, InvalidIndexError):
             # set using a non-recursive method & reset the cache
             if takeable:
                 self.iloc[index, col] = value


### PR DESCRIPTION
fix a bug of at indexer: when using df.at[slice, item] = array for existed item it will raise the pandas.errors.InvalidIndexError

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
